### PR TITLE
correct colors

### DIFF
--- a/modules/ext.proofreadpage.base.less
+++ b/modules/ext.proofreadpage.base.less
@@ -4,28 +4,28 @@
 
 /* stylelint-disable selector-class-pattern */
 .quality4 {
-	background-color: @background-color-success-subtle;
-	border-color: @background-color-success-subtle;
+	background-color: @background-color-green100;
+	border-color: @background-color-green100;
 }
 
 .quality3 {
-	background-color: @background-color-warning-subtle;
-	border-color: @background-color-warning-subtle;
+	background-color: @background-color-yellow100;
+	border-color: @background-color-yellow100;
 }
 
 .quality2 {
-	background-color: @background-color-progressive-subtle;
-	border-color: @background-color-progressive-subtle;
+	background-color: @background-color-blue100;
+	border-color: @background-color-blue100;
 }
 
 .quality1 {
-	background-color: @background-color-error-subtle;
-	border-color: @background-color-error-subtle;
+	background-color: @background-color-red100;
+	border-color: @background-color-red100;
 }
 
 .quality0 {
-	background-color: @background-color-notice-subtle;
-	border-color: @background-color-notice-subtle;
+	background-color: @background-color-muted;
+	border-color: @background-muted;
 }
 
 .pr_quality {


### PR DESCRIPTION
the variables for colors were used in the code a few days after their definition changed, which resulted in very pale colors. changed the variable names to reflect the value they used to have.